### PR TITLE
Use IO::File::WithPath to include path with filehandle

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ requires 'MIME::Types' => '2.03';
 requires 'Test::More';
 requires 'Moose';
 requires 'MooseX::Types';
+requires 'IO::File::WithPath';
 requires 'namespace::autoclean';
 
 test_requires 'Test::More';

--- a/lib/Catalyst/Plugin/Static/Simple.pm
+++ b/lib/Catalyst/Plugin/Static/Simple.pm
@@ -3,7 +3,7 @@ package Catalyst::Plugin::Static::Simple;
 use Moose::Role;
 use File::stat;
 use File::Spec ();
-use IO::File ();
+use IO::File::WithPath ();
 use MIME::Types ();
 use MooseX::Types::Moose qw/ArrayRef Str/;
 use Catalyst::Utils;
@@ -211,7 +211,7 @@ sub _serve_static {
         $c->res->headers->expires(time() + $config->{expires});
     }
 
-    my $fh = IO::File->new( $full_path, 'r' );
+    my $fh = eval { IO::File::WithPath->new( $full_path, 'r' ) };
     if ( defined $fh ) {
         binmode $fh;
         $c->res->body( $fh );


### PR DESCRIPTION
This will allow the XSendfile middleware to work properly.

This fixes RT#123644.